### PR TITLE
fix: replace %0A to \n in pdf export

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: '20.10.0'
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 8.15.0
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 8.15.0
       - name: Install dependencies

--- a/app/api/Downloader.ts
+++ b/app/api/Downloader.ts
@@ -4,6 +4,13 @@ import domtoimage from 'dom-to-image'
 export class Downloader {
   private readonly fileName: string = 'life-timeline'
 
+  private replaceEncodedNewlines(input: string): string {
+    return input.replace(/<p([^>]*)>(.*?)<\/p>/g, (match, p1, p2) => {
+      const replacedContent = p2.replace(/%0A/g, '\n')
+      return `<p${p1}>${replacedContent}</p>`
+    })
+  }
+
   /**
    * Downloads a file specified with the format
    * @param targetElement The HTML element to download.
@@ -52,13 +59,7 @@ export class Downloader {
             return false
           }
           const svgWithoutNewLine = match[0]
-          const replaceEncodedNewlines = (input: string): string => {
-            return input.replace(/<p([^>]*)>(.*?)<\/p>/g, (match, p1, p2) => {
-              const replacedContent = p2.replace(/%0A/g, '\n')
-              return `<p${p1}>${replacedContent}</p>`
-            })
-          }
-          const svg = replaceEncodedNewlines(svgWithoutNewLine)
+          const svg = this.replaceEncodedNewlines(svgWithoutNewLine)
 
           const fileName = `${this.fileName}.pdf`
 

--- a/app/api/Downloader.ts
+++ b/app/api/Downloader.ts
@@ -51,7 +51,14 @@ export class Downloader {
             console.error('Content to export is not found.')
             return false
           }
-          const svg = match[0]
+          const svgWithoutNewLine = match[0]
+          const replaceEncodedNewlines = (input: string): string => {
+            return input.replace(/<p([^>]*)>(.*?)<\/p>/g, (match, p1, p2) => {
+              const replacedContent = p2.replace(/%0A/g, '\n')
+              return `<p${p1}>${replacedContent}</p>`
+            })
+          }
+          const svg = replaceEncodedNewlines(svgWithoutNewLine)
 
           const fileName = `${this.fileName}.pdf`
 


### PR DESCRIPTION
# 概要
- PDF出力時に改行を含む文字列の改行箇所に`%0A`が表示されていたのを改行されるように修正しました。
- JIRA: [LT-76](https://naruhiyo.atlassian.net/browse/LT-76)

# 動作確認内容
- [x] 改行つきの文字列がPDF内でも改行されていること

## 修正前
<img width="926" alt="image" src="https://github.com/naruhiyo/life-timeline/assets/28133383/0efe2c8f-2480-444e-ad5a-2c7145d81d61">

## 修正後
<img width="929" alt="image" src="https://github.com/naruhiyo/life-timeline/assets/28133383/7ecf096b-3c1c-4607-84c6-bf04fb271c17">
